### PR TITLE
fix(index.html): Fix search with multiple words

### DIFF
--- a/backend/templates/songs/index.html
+++ b/backend/templates/songs/index.html
@@ -205,6 +205,7 @@
             ],
             paging: paging,
             perPage: 50,
+            searchQuerySeparator: ";",
             template: (options, dom) => `<div class='${options.classes.top}'>
                 <div class="input-group ${options.classes.search}">
                    <label class="input-group-text" for="search">{% trans "Search" %}</label>


### PR DESCRIPTION
With default separator being space,
 it meant that multi word search were interpreted
 as OR instead of AND
Fix by setting separator to a different character,
 which is not used regularly