### PR TITLE
chore: migrate from deprecated 'menu' to 'simple_menu' package

### DIFF
--- a/backend/menus.py
+++ b/backend/menus.py
@@ -2,7 +2,7 @@
 
 from django.urls import reverse
 from django.utils.translation import gettext_noop as _
-from menu import MenuItem, Menu
+from simple_menu import MenuItem, Menu
 
 from backend.auth import is_authenticated, is_localadmin, is_superadmin
 from backend.models import Song

--- a/chords/settings/base.py
+++ b/chords/settings/base.py
@@ -32,7 +32,7 @@ INSTALLED_APPS = [
     "tenants",
     "django_bootstrap5",
     "markdownx",
-    "menu",
+    "simple_menu",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/frontend/templates/base/index.html
+++ b/frontend/templates/base/index.html
@@ -1,7 +1,7 @@
 {% load static %}
 {% load django_bootstrap5 %}
 {% load i18n %}
-{% load menu %}
+{% load simple_menu %}
 {% load utils %}
 
 {% get_current_language as LANGUAGE_CODE %}

--- a/pdf/cachemenuitem.py
+++ b/pdf/cachemenuitem.py
@@ -1,7 +1,7 @@
 """Module for menu items stored in cache"""
 
 from django.core.cache import cache
-from menu import MenuItem
+from simple_menu import MenuItem
 
 
 class CacheMenuItem(MenuItem):

--- a/pdf/menus.py
+++ b/pdf/menus.py
@@ -2,7 +2,7 @@
 
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from menu import Menu, MenuItem
+from simple_menu import Menu, MenuItem
 
 from backend.auth import is_localadmin
 from pdf.models.request import ManualPDFTemplate, PDFFile


### PR DESCRIPTION
## Summary

- Replace all imports of `from menu import` with `from simple_menu import` across `backend/menus.py`, `pdf/menus.py`, and `pdf/cachemenuitem.py`
- Update `INSTALLED_APPS` in `chords/settings/base.py` from `"menu"` to `"simple_menu"`
- Update template tag load in `frontend/templates/base/index.html` from `{% load menu %}` to `{% load simple_menu %}`

Eliminates 2 `DeprecationWarning`s that appeared in every test run, as `django-simple-menu` v3 will remove the old `menu` compat shim.