### PR TITLE
perf(frontend): HTML/JS improvements to base and songs templates

### DIFF
--- a/backend/templates/songs/index.html
+++ b/backend/templates/songs/index.html
@@ -115,24 +115,10 @@
     const root = document.querySelector(':root');
 
     const data = await fetch("{{ data_url }}").then(r => r.json());
-    let obj = {
+    const obj = {
         headings: Object.keys(data[0]),
-
-        // data array
-        data: []
+        data: data.map(Object.values),
     };
-
-    // Loop over the objects to get the values
-    for ( let i = 0; i < data.length; i++ ) {
-
-        obj.data[i] = [];
-
-        for (let p in data[i]) {
-            if( data[i].hasOwnProperty(p) ) {
-                obj.data[i].push(data[i][p]);
-            }
-        }
-    }
     let table = null
     window.jsrender.views.settings.delimiters("<%", "%>")
     const template = window.jsrender.templates("#songTemplate")

--- a/backend/templates/songs/index.html
+++ b/backend/templates/songs/index.html
@@ -41,13 +41,10 @@
 {% endblock %}
 {% block body %}
     <script>
+        const scrollDownButton = document.getElementById("scroll-down");
         function show_scroll_button(event) {
-            const button = document.getElementById("scroll-down");
-            if (document.querySelector(".accordion-button:not(.collapsed)") !== null) {
-                button.classList.remove("d-none")
-                return;
-            }
-            button.classList.add("d-none")
+            scrollDownButton.classList.toggle("d-none",
+                document.querySelector(".accordion-button:not(.collapsed)") === null);
         }
     </script>
     <script id="songTemplate" type="text/x-jsrender">

--- a/backend/templates/songs/index.html
+++ b/backend/templates/songs/index.html
@@ -116,9 +116,10 @@
         headings: Object.keys(data[0]),
         data: data.map(Object.values),
     };
-    const domParser = new DOMParser();
+    const decodeTextarea = document.createElement("textarea");
     function decodeHtml(str) {
-        return domParser.parseFromString(str, 'text/html').body.innerHTML;
+        decodeTextarea.innerHTML = str;
+        return decodeTextarea.value;
     }
     let table = null
     window.jsrender.views.settings.delimiters("<%", "%>")
@@ -204,16 +205,13 @@
 
     let wakeLock = null;
     const requestWakeLock = async () => {
-          wakeLock = await navigator.wakeLock
-                .request('screen')
-                .catch(err => console.error('Failed to lock wake state with reason:', err.message))
-    
-          console.log("Screen WakeLock turned on")
-    
-          // listen for our release event
-          wakeLock.onrelease = function(ev) {
-            console.log("Screen WakeLock released")
-          }
+        try {
+            wakeLock = await navigator.wakeLock.request('screen');
+            wakeLock.onrelease = () => console.log("Screen WakeLock released");
+            console.log("Screen WakeLock turned on");
+        } catch (err) {
+            console.error('Failed to lock wake state with reason:', err.message);
+        }
     }
     const handleVisibilityChange = () => {
         if (wakeLock !== null && document.visibilityState === 'visible') {

--- a/backend/templates/songs/index.html
+++ b/backend/templates/songs/index.html
@@ -238,17 +238,8 @@
                 }
             }
     }
-    let hidden = false
     function hideChords(value) {
-        hidden = value
-        document.querySelectorAll(".chord").forEach(el => {
-            if (value) {
-                el.classList.add("d-none")
-            } else {
-                el.classList.remove("d-none")
-            }
-        })
-
+        root.classList.toggle("hide-chords", value);
     }
 
     const config = new Map([
@@ -266,12 +257,6 @@
                     table.on("datatable.init", () => {
                         document.getElementById("content").classList.remove("d-none");
                         document.getElementById("spinner").classList.add("d-none");
-                    })
-                    table.on("datatable.page", () => {
-                        hideChords(document.getElementById("hideChords").checked)
-                    })
-                    table.on("datatable.update", () => {
-                        hideChords(document.getElementById("hideChords").checked)
                     })
                 }
             }, true)],

--- a/backend/templates/songs/index.html
+++ b/backend/templates/songs/index.html
@@ -284,25 +284,22 @@
             element.disabled = true
         })
     }
-    document.addEventListener('DOMContentLoaded', function () {
-        const back_to_top = document.getElementById("back-to-top");
-        window.addEventListener('scroll', function (event) {
-            if (window.scrollY > 50) {
-                back_to_top.classList.remove("d-none");
-            } else {
-                back_to_top.classList.add("d-none");
-            }
-            event.stopPropagation()
-        });
-        // scroll body to 0px on click
-
-        back_to_top.addEventListener("click", (function () {
-          window.scroll({
+    const back_to_top = document.getElementById("back-to-top");
+    window.addEventListener('scroll', function (event) {
+        if (window.scrollY > 50) {
+            back_to_top.classList.remove("d-none");
+        } else {
+            back_to_top.classList.add("d-none");
+        }
+        event.stopPropagation()
+    });
+    // scroll body to 0px on click
+    back_to_top.addEventListener("click", function () {
+        window.scroll({
             top: 0,
             left: 0,
             behavior: 'smooth'
-          });
-        }));
+        });
     });
     </script>
 {% endblock %}

--- a/backend/templates/songs/index.html
+++ b/backend/templates/songs/index.html
@@ -6,7 +6,7 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block extra_head %}
-    <script async src="{% static 'js/chords.js' %}"></script>
+    <script defer src="{% static 'js/chords.js' %}"></script>
     <script defer type="text/javascript" src="{% static 'js/simple-datatables.js' %}"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jsrender/1.0.15/jsrender.min.js"
             integrity="sha512-6heofwTnm0osmeEuz47jQLMVpAe2/ww+hZ4xvyv/kgedYO0b9mhNnsh8nUQZrmcdbaDkxrN+1K4SV6L+V4EH6Q=="
@@ -14,8 +14,6 @@
             referrerpolicy="no-referrer"
             defer>
     </script>
-    <script type="module" src="{% static 'js/js.cookie.js' %}"></script>
-    <script type="module" src="{% static 'js/Options.js' %}"></script>
 {%  endblock %}
 {% block extra_options %}
 <div class="ms-2 me-2 mt-1 form-floating">
@@ -42,7 +40,7 @@
 </div>
 {% endblock %}
 {% block body %}
-    <script async>
+    <script>
         function show_scroll_button(event) {
             const button = document.getElementById("scroll-down");
             if (document.querySelector(".accordion-button:not(.collapsed)") !== null) {

--- a/backend/templates/songs/index.html
+++ b/backend/templates/songs/index.html
@@ -272,13 +272,15 @@
         })
     }
     const back_to_top = document.getElementById("back-to-top");
-    window.addEventListener('scroll', function (event) {
-        if (window.scrollY > 50) {
-            back_to_top.classList.remove("d-none");
-        } else {
-            back_to_top.classList.add("d-none");
+    let ticking = false;
+    window.addEventListener('scroll', function () {
+        if (!ticking) {
+            requestAnimationFrame(() => {
+                back_to_top.classList.toggle("d-none", window.scrollY <= 50);
+                ticking = false;
+            });
+            ticking = true;
         }
-        event.stopPropagation()
     });
     // scroll body to 0px on click
     back_to_top.addEventListener("click", function () {

--- a/backend/templates/songs/index.html
+++ b/backend/templates/songs/index.html
@@ -119,6 +119,10 @@
         headings: Object.keys(data[0]),
         data: data.map(Object.values),
     };
+    const domParser = new DOMParser();
+    function decodeHtml(str) {
+        return domParser.parseFromString(str, 'text/html').body.innerHTML;
+    }
     let table = null
     window.jsrender.views.settings.delimiters("<%", "%>")
     const template = window.jsrender.templates("#songTemplate")
@@ -140,8 +144,6 @@
             hiddenHeader: true,
             perPageSelect: false,
             rowRender: function (rowValue, tr, index) {
-                const textarea = document.createElement("textarea");
-                textarea.innerHTML = rowValue.cells[7].data;
                 const number = rowValue.cells[6].text
                 const row = {
                     "number": number,
@@ -151,7 +153,7 @@
                     "link": rowValue.cells[4].text,
                     "archived": rowValue.cells[5].text === "true",
                     "id": rowValue.cells[0].text,
-                    "text": textarea.value,
+                    "text": decodeHtml(rowValue.cells[7].data),
                     "shown": document.getElementById("id" + number)?.classList.contains("show") ?? false,
                 }
                 {% if user.is_authenticated %}

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -37,7 +37,10 @@
      font-weight: bold;
      font-size: 100%;
      vertical-align: super;
-}
+ }
+ .hide-chords .chord {
+     display: none;
+ }
  @media (min-width: 768px) {
      .transposer {
          max-width: 100px;

--- a/frontend/templates/base/index.html
+++ b/frontend/templates/base/index.html
@@ -51,7 +51,7 @@
             <ul class="navbar-nav nav-left ms-1">
                 {% draw_menu "files" use_tenant=True %}
             </ul>
-            {% if request.tenant.links.all|length > 0 %}
+            {% if request.tenant.links.all %}
             <ul class="navbar-nav nav-left ms-1">
                 {% draw_menu "links" use_tenant=True %}
             </ul>
@@ -137,7 +137,6 @@
         Here should be your text
     {% endblock %}
 </div>
-</body>
 <script type="module">
     document.getElementById("options").addEventListener('click', function(event){
         // The event won't be propagated up to the document NODE and
@@ -166,4 +165,5 @@
     });
 
 </script>
+</body>
 </html>

--- a/frontend/templates/base/index.html
+++ b/frontend/templates/base/index.html
@@ -24,7 +24,6 @@
               defer></script>
     <link rel="stylesheet" type="text/css" href="{% static 'icons/css/songs.css' %}">
     <link rel="stylesheet" type="text/css" href="{% static 'styles.css' %}">
-    <script type="module" src="{% static "js/qr.mjs" %}"></script>
     {% block extra_head %} {% endblock %}
     <style>
         html, body {


### PR DESCRIPTION
## Summary

- Remove redundant `qr.mjs` `<script>` tag from `<head>` — already fetched via `import` in the inline module
- Fix invalid HTML: move inline `<script type="module">` from after `</body>` to before it
- Fix `links.all|length > 0` queryset over-evaluation — replace with truthy check
- Fix script loading: `chords.js` `async` → `defer` to prevent race with `onclick` handlers; remove no-op `async` on inline script; remove redundant standalone module tags for `js.cookie.js` and `Options.js`
- Simplify song data reshape: replace nested for-in loop with `data.map(Object.values)`
- Remove dead `DOMContentLoaded` wrapper — the callback never fired since ES modules run after DOM is already parsed
- Reuse a single `<textarea>` for HTML-decoding instead of allocating one per row render
- Replace `querySelectorAll(".chord")` per-element DOM writes in `hideChords` with a single CSS class toggle on the root element; removes `datatable.page`/`datatable.update` re-apply listeners
- Throttle scroll handler with `requestAnimationFrame` — at most one DOM write per animation frame
- Cache `getElementById` result in `show_scroll_button` and simplify branch to `classList.toggle`
- Fix `wakeLock` undefined dereference when `navigator.wakeLock.request()` rejects